### PR TITLE
feat: add extends parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ GitHub Action for [Semantic Release](https://github.com/semantic-release/semanti
   * `semantic_version`: [Optional] Specify specifying version range for semantic-release. If no version range is specified, semantic-release@^15 will be used by default.
   * `extra_plugins`: [Optional] Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.
   * `dry_run`: [Optional] Whether to run semantic release in `dry-run` mode. It will override the dryRun attribute in your configuration file.
+  * `extends`: [Optional] Shareable configuration to use. It will override the extends attribute in your configuration file.
 * outputs:
   * `new_release_published`: Whether a new release was published. `true` or `false`
   * `new_release_version`: Version of the new release
@@ -55,6 +56,7 @@ steps:
       extra_plugins: |
         @semantic-release/git
         @semantic-release/changelog@3.0.0
+      extends: .github/release.config.js
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,8 @@ inputs:
     description: 'Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.'
   dry_run:
     description: 'Whether to run semantic release in `dry-run` mode. It will override the dryRun attribute in your configuration file'
+  extends:
+    description: 'Shareable configuration to use. It will override the extends attribute in your configuration file.'
 outputs:
   new_release_published:
     description: 'Whether a new release was published'

--- a/src/handleOptions.js
+++ b/src/handleOptions.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const core = require('@actions/core');
 const inputs = require('./inputs.json');
 
@@ -44,7 +45,7 @@ exports.handleExtendsOption = () => {
   const _extends = core.getInput(inputs.extends);
 
   if (_extends) {
-    extendsOption.extends = _extends;
+    extendsOption.extends = path.resolve(_extends);
   }
 
   return extendsOption;

--- a/src/handleOptions.js
+++ b/src/handleOptions.js
@@ -41,10 +41,10 @@ exports.handleDryRunOption = () => {
  */
 exports.handleExtendsOption = () => {
   const extendsOption = {};
-  const extends = core.getInput(inputs.extends);
+  const _extends = core.getInput(inputs.extends);
 
   if (extends) {
-    extendsOption.extends = extends;
+    extendsOption.extends = _extends;
   }
 
   return extendsOption;

--- a/src/handleOptions.js
+++ b/src/handleOptions.js
@@ -43,7 +43,7 @@ exports.handleExtendsOption = () => {
   const extendsOption = {};
   const _extends = core.getInput(inputs.extends);
 
-  if (extends) {
+  if (_extends) {
     extendsOption.extends = _extends;
   }
 

--- a/src/handleOptions.js
+++ b/src/handleOptions.js
@@ -34,3 +34,18 @@ exports.handleDryRunOption = () => {
       return {};
   }
 };
+
+/**
+ * Handle Extends Option
+ * @returns {{}|{extends: string}}
+ */
+exports.handleExtendsOption = () => {
+  const extendsOption = {};
+  const extends = core.getInput(inputs.extends);
+
+  if (extends) {
+    extendsOption.extends = extends;
+  }
+
+  return extendsOption;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const core = require('@actions/core');
-const {handleBranchOption, handleDryRunOption} = require('./handleOptions');
+const {handleBranchOption, handleDryRunOption, handleExtendsOption} = require('./handleOptions');
 const setUpJob = require('./setUpJob.task');
 const installSpecifyingVersionSemantic = require('./installSpecifyingVersionSemantic.task');
 const preInstallPlugins = require('./preInstallPlugins.task');
@@ -19,6 +19,7 @@ const release = async () => {
   const result = await semanticRelease({
     ...(handleBranchOption()),
     ...(handleDryRunOption()),
+    ...(handleExtendsOption()),
   });
 
   await cleanupNpmrc();

--- a/src/inputs.json
+++ b/src/inputs.json
@@ -2,5 +2,6 @@
   "branch": "branch",
   "semantic_version": "semantic_version",
   "extra_plugins": "extra_plugins",
-  "dry_run": "dry_run"
+  "dry_run": "dry_run",
+  "extends": "extends"
 }


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Describe Changes
<!-- Describe your changes in detail, if applicable. -->
Adds a `extends` input which is passed down to semantic-release to set a custom shareable configuration.

It can reference a local file (eg: non-standard path), or a npm package (that will need to be installed with `extra_plugins`).

