### PR TITLE
fix(branch): parameter `branch` does not work in semantic v16

### DIFF
--- a/.github/workflows/checkPullRequest.yml
+++ b/.github/workflows/checkPullRequest.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Semantic Release
         uses: ./
         with:
+          branch: master
           extra_plugins: |
             @semantic-release/git
             @semantic-release/changelog

--- a/.github/workflows/testRelease.yml
+++ b/.github/workflows/testRelease.yml
@@ -20,6 +20,7 @@ jobs:
         uses: cycjimmy/semantic-release-action@v2
         id: semantic
         with:
+          branch: master
           extra_plugins: |
             @semantic-release/git
             @semantic-release/changelog

--- a/src/handleOptions.js
+++ b/src/handleOptions.js
@@ -9,8 +9,18 @@ exports.handleBranchOption = () => {
   const branchOption = {};
   const branch = core.getInput(inputs.branch);
 
-  if (branch) {
+  if (!branch) {
+    return branchOption;
+  }
+
+  const semanticVersion = require('semantic-release/package.json').version;
+  const semanticMajorVersion = Number(semanticVersion.replace(/\..+/g, ''));
+  core.debug(`semanticMajorVersion: ${semanticMajorVersion}`);
+
+  if (semanticMajorVersion < 16) {
     branchOption.branch = branch;
+  } else {
+    branchOption.branches = [branch];
   }
 
   return branchOption;


### PR DESCRIPTION
parameter `branch` does not work in semantic v16(#15)

#15

### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- Fixes #15 

### Describe Changes
<!-- Describe your changes in detail, if applicable. -->
fix parameter `branch` does not work in semantic v16

