### PR TITLE
feat: add release notes to output

### DIFF
--- a/.github/workflows/testRelease.yml
+++ b/.github/workflows/testRelease.yml
@@ -36,4 +36,5 @@ jobs:
           echo ${{ steps.semantic.outputs.new_release_major_version }}
           echo ${{ steps.semantic.outputs.new_release_minor_version }}
           echo ${{ steps.semantic.outputs.new_release_patch_version }}
+          echo ${{ steps.semantic.outputs.new_release_notes }}
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ GitHub Action for [Semantic Release](https://github.com/semantic-release/semanti
   * `new_release_major_version`: Major version of the new release
   * `new_release_minor_version`: Minor version of the new release
   * `new_release_patch_version`: Patch version of the new release
+  * `new_release_notes`: The release notes for the new release.
   
 ### Examples
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,8 @@ outputs:
     description: 'Minor version of the new release'
   new_release_patch_version:
     description: 'Patch version of the new release'
+  new_release_notes:
+    description: 'The release notes for the new release.'
 runs:
   using: 'node12'
   main: 'index.js'

--- a/src/outputs.json
+++ b/src/outputs.json
@@ -3,5 +3,6 @@
   "new_release_version": "new_release_version",
   "new_release_major_version": "new_release_major_version",
   "new_release_minor_version": "new_release_minor_version",
-  "new_release_patch_version": "new_release_patch_version"
+  "new_release_patch_version": "new_release_patch_version",
+  "new_release_notes": "new_release_notes"
 }

--- a/src/windUpJob.task.js
+++ b/src/windUpJob.task.js
@@ -24,7 +24,7 @@ module.exports = async (result) => {
     core.debug(`The release was published with plugin "${release.pluginName}".`);
   }
 
-  const {version} = nextRelease;
+  const {version, notes} = nextRelease;
   const [major, minor, patch] = version.split('.');
 
   // set outputs
@@ -33,4 +33,5 @@ module.exports = async (result) => {
   core.setOutput(outputs.new_release_major_version, major);
   core.setOutput(outputs.new_release_minor_version, minor);
   core.setOutput(outputs.new_release_patch_version, patch);
+  core.setOutput(outputs.new_release_notes, notes);
 };


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Describe Changes
Adds the [release notes](https://semantic-release.gitbook.io/semantic-release/developer-guide/js-api#nextrelease) of the next release to the output of the action.


### Use-case:
Dry run semantic-release-action to determine nextRelease version and create a PR for new version.
```yml
- name: Dry run Semantic release
  id: semantic
  uses: cycjimmy/semantic-release-action@latest
  with:
    dry_run: true
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

- name: Create Pull Request
  uses: peter-evans/create-pull-request@v2
  if: steps.semantic.outputs.new_release_published == 'true'
  with:
    branch: 'release/${{ steps.semantic.outputs.new_release_version }}'
    token: ${{ secrets.GITHUB_TOKEN }}
    commit-message: 'chore(Version): Prepare v${{ steps.semantic.outputs.new_release_version }}. Merge release/${{ steps.semantic.outputs.new_release_version }} into develop.'
    title: Prepare v${{ steps.semantic.outputs.new_release_version }}
    body: ${{ steps.semantic.outputs.new_release_notes }}
```

**Output example:**

<img width="746" alt="Screenshot 2020-03-15 at 09 54 50" src="https://user-images.githubusercontent.com/2543633/76698430-179ba480-66a3-11ea-84c6-af19eb4bd4ad.png">


