### PR TITLE
fix: use error loglevel for installing dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 const run = async () => {
   // Install Dependencies
   {
-    const {stdout, stderr} = await exec('npm ci --only=prod', {
+    const {stdout, stderr} = await exec('npm --loglevel error ci --only=prod', {
       cwd: path.resolve(__dirname)
     });
     console.log(stdout);


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [X] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- Fixes #57 

### Describe Changes
Warnings during dependencies installation are not meant to make crash the release.
So by setting the loglevel to error we are sure we stop the release process only when a real error occurs.
