### PR TITLE
feat: add output for last release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ steps:
 | new_release_patch_version | Patch version of the new release. (e.g. `0`) |
 | new_release_channel       | The distribution channel on which the last release was initially made available (undefined for the default distribution channel). |
 | new_release_notes         | The release notes for the new release. |
+| last_release_version      | Version of the previous release, if there was one. (e.g. `1.2.0`) |
 
 #### Using Output Variables:
 ```yaml

--- a/src/outputs.json
+++ b/src/outputs.json
@@ -5,5 +5,6 @@
   "new_release_minor_version": "new_release_minor_version",
   "new_release_patch_version": "new_release_patch_version",
   "new_release_channel": "new_release_channel",
-  "new_release_notes": "new_release_notes"
+  "new_release_notes": "new_release_notes",
+  "last_release_version": "last_release_version"
 }

--- a/src/windUpJob.task.js
+++ b/src/windUpJob.task.js
@@ -40,4 +40,5 @@ module.exports = async (result) => {
   core.setOutput(outputs.new_release_patch_version, patch);
   core.setOutput(outputs.new_release_channel, channel);
   core.setOutput(outputs.new_release_notes, notes);
+  core.setOutput(outputs.last_release_version, lastRelease.version)
 };


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Describe Changes
<!-- Describe your changes in detail, if applicable. -->
This PR adds another output containing the previously released version (if available) from the semantic-release return values. Such an output is useful for workflows that want to look up the previous version, but don't commit back the version in the sources. We just ran into such a case and would love to see it integrated here natively instead of us having to write a custom script that looks up the most recent relevant tag.

