### PR TITLE
feat: add working dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,15 @@ then make sure that you configure this in your `package.json` file:
 ```
 
 ### Inputs
-| Input Parameter  | Required | Description |
-|:----------------:|:--------:|-------------|
-| semantic_version | false    | Specify specifying version range for semantic-release. [[Details](#semantic_version)] |
-| branches         | false    | The branches on which releases should happen.[[Details](#branches)]<br>Support for **semantic-release above v16**. |
-| branch           | false    | The branch on which releases should happen.[[Details](#branch)]<br>Only support for **semantic-release older than v16**. |
-| extra_plugins    | false    | Extra plugins for pre-install. [[Details](#extra_plugins)] |
-| dry_run          | false    | Whether to run semantic release in `dry-run` mode. [[Details](#dry_run)] |
-| extends          | false    | Use a sharable configuration [[Details](#extends)] |
+| Input Parameter   | Required | Description |
+|:-----------------:|:--------:|-------------|
+| semantic_version  | false    | Specify specifying version range for semantic-release. [[Details](#semantic_version)] |
+| branches          | false    | The branches on which releases should happen.[[Details](#branches)]<br>Support for **semantic-release above v16**. |
+| branch            | false    | The branch on which releases should happen.[[Details](#branch)]<br>Only support for **semantic-release older than v16**. |
+| extra_plugins     | false    | Extra plugins for pre-install. [[Details](#extra_plugins)] |
+| dry_run           | false    | Whether to run semantic release in `dry-run` mode. [[Details](#dry_run)] |
+| extends           | false    | Use a sharable configuration [[Details](#extends)] |
+| working_directory | false    | Use another working directory for semantic release [[Details](#working_directory)] |
 
 #### semantic_version
 > {Optional Input Parameter} Specify specifying version range for semantic-release.<br>If no version range is specified, latest version will be used by default.
@@ -201,6 +202,23 @@ steps:
       # You can extend an existing shareable configuration.
       extends: |
         @semantic-release/apm-config
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+#### working_directory
+This action run semantic release in the github provided workspace by default. You can override it by setting another working directory.
+
+```yaml
+steps:
+  - name: Checkout
+    uses: actions/checkout@v2
+  - name: Semantic Release
+    uses: cycjimmy/semantic-release-action@v2
+    with:
+      # You can select another working directory like a subdirectory for example.
+      working_directory: ./code
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   extends:
     required: false
     description: 'One or several sharable configurations, https://semantic-release.gitbook.io/semantic-release/usage/configuration#extends'
+  working_directory:
+    required: false
+    description: 'Specify another working directory for semantic release. Default one is provided by github.'
 outputs:
   new_release_published:
     description: 'Whether a new release was published'

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,9 @@ const inputs = require('./inputs.json');
  * @returns {Promise<void>}
  */
 const release = async () => {
+  if (core.getInput(inputs.working_directory)) {
+    process.chdir(core.getInput(inputs.working_directory));
+  }
   await setUpJob();
   await installSpecifyingVersionSemantic();
   await preInstall(core.getInput(inputs.extra_plugins));

--- a/src/inputs.json
+++ b/src/inputs.json
@@ -4,5 +4,6 @@
   "branch": "branch",
   "extra_plugins": "extra_plugins",
   "dry_run": "dry_run",
-  "extends": "extends"
+  "extends": "extends",
+  "working_directory": "working_directory"
 }


### PR DESCRIPTION
### Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Describe Changes
You can now select another working directory like a subdirectory of the project to run semantic release.

The goal is to manage a mono-repo with semantic release and run this action in every project.

