### PR TITLE
feat: switch operating environment to node16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: ./
         id: semantic
         with:
           extra_plugins: |
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js with GitHub Package Registry
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           registry-url: 'https://npm.pkg.github.com'
           scope: 'cycjimmy'
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ steps:
   - name: Checkout
     uses: actions/checkout@v3
   - name: Semantic Release
-    uses: cycjimmy/semantic-release-action@v2
+    uses: cycjimmy/semantic-release-action@v3
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -61,7 +61,7 @@ steps:
   - name: Checkout
     uses: actions/checkout@v3
   - name: Semantic Release
-    uses: cycjimmy/semantic-release-action@v2
+    uses: cycjimmy/semantic-release-action@v3
     with:
       semantic_version: 15.13.28  # It is recommended to specify specifying version range
                                   # for semantic-release.
@@ -80,7 +80,7 @@ steps:
   - name: Checkout
     uses: actions/checkout@v3
   - name: Semantic Release
-    uses: cycjimmy/semantic-release-action@v2
+    uses: cycjimmy/semantic-release-action@v3
     with:
       semantic_version: 16
       # you can set branches for semantic-release above v16.
@@ -126,7 +126,7 @@ steps:
   - name: Checkout
     uses: actions/checkout@v3
   - name: Semantic Release
-    uses: cycjimmy/semantic-release-action@v2
+    uses: cycjimmy/semantic-release-action@v3
     with:
       semantic_version: 15.13.28
       # you can set branch for semantic-release older than v16.
@@ -151,7 +151,7 @@ steps:
   - name: Checkout
     uses: actions/checkout@v3
   - name: Semantic Release
-    uses: cycjimmy/semantic-release-action@v2
+    uses: cycjimmy/semantic-release-action@v3
     with:
       # You can specify specifying version range for the extra plugins if you prefer.
       extra_plugins: |
@@ -181,7 +181,7 @@ steps:
   - name: Checkout
     uses: actions/checkout@v3
   - name: Semantic Release
-    uses: cycjimmy/semantic-release-action@v2
+    uses: cycjimmy/semantic-release-action@v3
     with:
       dry_run: true
     env:
@@ -197,7 +197,7 @@ steps:
   - name: Checkout
     uses: actions/checkout@v3
   - name: Semantic Release
-    uses: cycjimmy/semantic-release-action@v2
+    uses: cycjimmy/semantic-release-action@v3
     with:
       # You can extend an existing shareable configuration.
       extends: |
@@ -215,7 +215,7 @@ steps:
   - name: Checkout
     uses: actions/checkout@v3
   - name: Semantic Release
-    uses: cycjimmy/semantic-release-action@v2
+    uses: cycjimmy/semantic-release-action@v3
     with:
       # You can select another working directory like a subdirectory for example.
       working_directory: ./code
@@ -242,7 +242,7 @@ steps:
   - name: Checkout
     uses: actions/checkout@v3
   - name: Semantic Release
-    uses: cycjimmy/semantic-release-action@v2
+    uses: cycjimmy/semantic-release-action@v3
     id: semantic   # Need an `id` for output variables
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -44,5 +44,5 @@ outputs:
   last_release_version:
     description: 'Version of the previous release, if there was one.'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
switch operating environment to node16

BREAKING CHANGE: switch operating environment to node16

#92, #96

### Type of Change
<!-- What type of change does your code introduce? -->
- [x] New feature
- [x] Bug fix
- [x] Documentation
- [ ] Refactor
- [ ] Chore

### Describe Changes
<!-- Describe your changes in detail, if applicable. -->
`semantic-release@19` no longer supports environments below node16
