### PR TITLE
feat: handle versioned extends inputs correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,10 @@ steps:
     uses: cycjimmy/semantic-release-action@v3
     with:
       # You can extend an existing shareable configuration.
+      # And you can specify version range for the shareable configuration if you prefer.
       extends: |
-        @semantic-release/apm-config
+        @semantic-release/apm-config@^9.0.0
+        @mycompany/override-config
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/src/handleOptions.js
+++ b/src/handleOptions.js
@@ -68,7 +68,11 @@ exports.handleExtends = () => {
   const extend = core.getInput(inputs.extends);
 
   if (extend) {
-    return { extends: extend };
+    const extendModuleNames = extend.split(/\r?\n/)
+      .map((name) => name.replace(/(?<!^)@.+/, ''))
+    return {
+      extends: extendModuleNames
+    };
   } else {
     return {};
   }


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Describe Changes
<!-- Describe your changes in detail, if applicable. -->

In some cases, you may want to provide a version for the config you want to extend. This change will now pass the correct format for such a case down to semantic-release (just the module name, i.e. removing everything after `@`). It handles scoped packages with a negative lookbehind to make sure that package names starting with `@` are not replaced. The format passed to npm install is kept the same as before, so that will keep on working.

More specifically, such an input will now work:

```yaml
extends: |
  @semantic-release/apm-config@^9.0.0
  @mycompany/override-config
```

