### PR TITLE
Fix set last_release_version output even if no release has been published

### DIFF
--- a/src/windUpJob.task.js
+++ b/src/windUpJob.task.js
@@ -14,16 +14,17 @@ module.exports = async (result) => {
 
   const {lastRelease, commits, nextRelease, releases} = result;
 
+  if (lastRelease.version) {
+    core.debug(`The last release was "${lastRelease.version}".`);
+    core.setOutput(outputs.last_release_version, lastRelease.version)
+  }
+
   if (!nextRelease) {
     core.debug('No release published.');
     return Promise.resolve();
   }
 
   core.debug(`Published ${nextRelease.type} release version ${nextRelease.version} containing ${commits.length} commits.`);
-
-  if (lastRelease.version) {
-    core.debug(`The last release was "${lastRelease.version}".`);
-  }
 
   for (const release of releases) {
     core.debug(`The release was published with plugin "${release.pluginName}".`);
@@ -40,5 +41,4 @@ module.exports = async (result) => {
   core.setOutput(outputs.new_release_patch_version, patch);
   core.setOutput(outputs.new_release_channel, channel);
   core.setOutput(outputs.new_release_notes, notes);
-  core.setOutput(outputs.last_release_version, lastRelease.version)
 };


### PR DESCRIPTION
Fixed that now the `last_release_version` output gets set even when no new release has been published

### Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Describe Changes
With this change, the `last_release_version` option will be set whenever available.
Previously this has been set only when a new release version was available, too.

