### PR TITLE
chore: rename default branch to main

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,2 +1,2 @@
 # Contributing
-The repository is released under the MIT license, and follows a standard Github development process, using Github tracker for issues and merging pull requests into master.
+The repository is released under the MIT license, and follows a standard Github development process, using Github tracker for issues and merging pull requests into main.

--- a/.github/workflows/checkPullRequest.yml
+++ b/.github/workflows/checkPullRequest.yml
@@ -3,7 +3,7 @@ name: Check Pull Request
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   release:
@@ -16,7 +16,7 @@ jobs:
       - name: Semantic Release
         uses: ./
         with:
-          branch: master
+          branch: main
           extra_plugins: |
             @semantic-release/git
             @semantic-release/changelog

--- a/.github/workflows/testRelease.yml
+++ b/.github/workflows/testRelease.yml
@@ -69,11 +69,11 @@ jobs:
           dry_run: true
           branches: |
             [
-              'master',
+              'main',
               {name: 'beta', prerelease: true},
               {name: 'alpha', prerelease: true}
             ]
-          branch: master
+          branch: main
           extra_plugins: |
             @semantic-release/git@7
             @semantic-release/changelog@3

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 GitHub Action for [Semantic Release][semantic-url]. 
 
 ## Usage
-### Step1: Set any [Semantic Release Configuration](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration) in your repository.
+### Step1: Set any [Semantic Release Configuration](https://github.com/semantic-release/semantic-release/blob/main/docs/usage/configuration.md#configuration) in your repository.
 
-### Step2: [Add Secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) in your repository for the [Semantic Release Authentication](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/ci-configuration.md#authentication) Environment Variables.
+### Step2: [Add Secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) in your repository for the [Semantic Release Authentication](https://github.com/semantic-release/semantic-release/blob/main/docs/usage/ci-configuration.md#authentication) Environment Variables.
 
 ### Step3: Add a [Workflow File](https://help.github.com/en/articles/workflow-syntax-for-github-actions) to your repository to create custom automated processes.
 
@@ -277,8 +277,8 @@ This project is released under the [MIT License][license-url].
 [semantic-url]: https://github.com/semantic-release/semantic-release
 
 [license-image]: https://img.shields.io/npm/l/@cycjimmy/semantic-release-action.svg
-[license-url]: https://github.com/cycjimmy/semantic-release-action/blob/master/LICENSE
+[license-url]: https://github.com/cycjimmy/semantic-release-action/blob/main/LICENSE
 
-[changelog-url]: https://github.com/cycjimmy/semantic-release-action/blob/master/docs/CHANGELOG.md
+[changelog-url]: https://github.com/cycjimmy/semantic-release-action/blob/main/docs/CHANGELOG.md
 
 [github-packages-registry]: https://github.com/features/packages


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [x] Chore

### Describe Changes
Refers to this repository's default branch as `main`, which is the new default for GitHub repositories, and is more politically correct. Note that you will still need to [rename the master branch manually](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch).