### PR TITLE
fix(actions): update @actions/core to cope with new output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.6.0",
+        "@actions/core": "^1.10.0",
         "@cycjimmy/awesome-js-funcs": "^4.0.4",
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/git": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/cycjimmy/semantic-release-action#readme",
   "dependencies": {
-    "@actions/core": "^1.6.0",
+    "@actions/core": "^1.10.0",
     "@cycjimmy/awesome-js-funcs": "^4.0.4",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands

### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- Fixes #127

### Describe Changes
upgrade @actions/core to the latest version to avoid deprecated output warnings

see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

