### PR TITLE
feat: Add new outputs for git head and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,11 @@ steps:
 | new_release_patch_version | Patch version of the new release. (e.g. `"0"`)                                                                                    |
 |    new_release_channel    | The distribution channel on which the last release was initially made available (undefined for the default distribution channel). |
 |     new_release_notes     | The release notes for the new release.                                                                                            |
-|   last_release_version    | Version of the previous release, if there was one. (e.g. `"1.2.0"`)                                                               |
+| new_release_git_head      | The sha of the last commit being part of the new release |
+| new_release_git_tag       | The Git tag associated with the new release. |
+| last_release_version      | Version of the previous release, if there was one. (e.g. `1.2.0`) |
+| last_release_git_head     | The sha of the last commit being part of the last release, if there was one. |
+| last_release_git_tag      | The Git tag associated with the last release, if there was one. |                                                         |
 
 #### Using Output Variables:
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -41,8 +41,16 @@ outputs:
     description: 'The distribution channel on which the last release was initially made available (undefined for the default distribution channel).'
   new_release_notes:
     description: 'The release notes for the new release.'
+  new_release_git_head:
+    description: 'The sha of the last commit being part of the new release.'
+  new_release_git_tag:
+    description: 'The Git tag associated with the new release.'
   last_release_version:
     description: 'Version of the previous release, if there was one.'
+  last_release_git_head:
+    description: 'The sha of the last commit being part of the last release, if there was one.'
+  last_release_git_tag:
+    description: 'The Git tag associated with the last release, if there was one.'
 runs:
   using: 'node16'
   main: 'index.js'

--- a/src/outputs.json
+++ b/src/outputs.json
@@ -5,6 +5,10 @@
   "new_release_minor_version": "new_release_minor_version",
   "new_release_patch_version": "new_release_patch_version",
   "new_release_channel": "new_release_channel",
-  "new_release_notes": "new_release_notes",
-  "last_release_version": "last_release_version"
+  "new_release_notes": "new_release_notes",  
+  "new_release_git_head": "new_release_git_head",
+  "new_release_git_tag": "new_release_git_tag",
+  "last_release_version": "last_release_version",
+  "last_release_git_head": "last_release_git_head",
+  "last_release_git_tag": "last_release_git_tag"
 }

--- a/src/windUpJob.task.js
+++ b/src/windUpJob.task.js
@@ -30,7 +30,7 @@ module.exports = async (result) => {
     core.debug(`The release was published with plugin "${release.pluginName}".`);
   }
 
-  const {version, channel, notes} = nextRelease;
+  const {version, channel, notes, gitHead, gitTag} = nextRelease;
   const [major, minor, patch] = version.split(/\.|-|\s/g, 3);
 
   // set outputs
@@ -40,5 +40,10 @@ module.exports = async (result) => {
   core.setOutput(outputs.new_release_minor_version, minor);
   core.setOutput(outputs.new_release_patch_version, patch);
   core.setOutput(outputs.new_release_channel, channel);
-  core.setOutput(outputs.new_release_notes, notes);
+  core.setOutput(outputs.new_release_notes, notes);  
+  core.setOutput(outputs.new_release_git_head, gitHead);
+  core.setOutput(outputs.new_release_git_tag, gitTag);
+  core.setOutput(outputs.last_release_version, lastRelease.version);
+  core.setOutput(outputs.last_release_git_head, lastRelease.gitHead);
+  core.setOutput(outputs.last_release_git_tag, lastRelease.gitTag);
 };


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- Fixes #135

### Describe Changes
This adds new outputs for the git head and tag for new and last release: new_release_git_head, new_release_git_tag, last_release_git_head, last_release_git_tag

