### PR TITLE
feat: add `ci` input parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ then make sure that you configure this in your `package.json` file:
 |      branch       |  false   | The branch on which releases should happen.[[Details](#branch)]<br>Only support for **semantic-release older than v16**. |
 |   extra_plugins   |  false   | Extra plugins for pre-install. [[Details](#extra_plugins)]                                                               |
 |      dry_run      |  false   | Whether to run semantic release in `dry-run` mode. [[Details](#dry_run)]                                                 |
+|        ci         |  false   | Whether to run semantic release with CI support. [[Details](#ci)]<br>Support for **semantic-release above v16**.         |
 |      extends      |  false   | Use a sharable configuration [[Details](#extends)]                                                                       |
 | working_directory |  false   | Use another working directory for semantic release [[Details](#working_directory)]                                       |
 
@@ -191,6 +192,24 @@ steps:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
+
+#### ci
+> {Optional Input Parameter} Whether to run semantic release with CI support (default true).<br>`ci` supports for **semantic-release above v16**.
+
+```yaml
+steps:
+  - name: Checkout
+    uses: actions/checkout@v3
+  - name: Semantic Release
+    uses: cycjimmy/semantic-release-action@v3
+    with:
+      ci: false
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+`ci` can be used, e.g in combination with `dry_run` when generating the next release version in pull requests, where `semantic_release` would normally block the execution.
 
 #### extends
 The action can be used with `extends` option to extend an existing [sharable configuration](https://semantic-release.gitbook.io/semantic-release/usage/shareable-configurations) of semantic-release. Can be used in combination with `extra_plugins`.

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   dry_run:
     required: false
     description: 'Whether to run semantic release in `dry-run` mode. It will override the dryRun attribute in your configuration file'
+  ci:
+    required: false
+    description: 'Whether to run semantic release with CI support (default: true). It will override the ci attribute in your configuration file'
   extends:
     required: false
     description: 'One or several sharable configurations, https://semantic-release.gitbook.io/semantic-release/usage/configuration#extends'

--- a/src/handleOptions.js
+++ b/src/handleOptions.js
@@ -61,6 +61,25 @@ exports.handleDryRunOption = () => {
 };
 
 /**
+ * Handle Ci Option
+ * @returns {{}|{ci: boolean}}
+ */
+exports.handleCiOption = () => {
+  const ci = core.getInput(inputs.ci);
+
+  switch (ci) {
+    case 'true':
+      return { ci: true, noCi: false };
+
+    case 'false':
+      return { ci: false, noCi: true };
+
+    default:
+      return {};
+  }
+};
+
+/**
  * Handle Extends Option
  * @returns {{}|{extends: Array}|{extends: String}}
  */

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const core = require('@actions/core');
 const {
   handleBranchesOption,
   handleDryRunOption,
+  handleCiOption,
   handleExtends,
 } = require('./handleOptions');
 const setUpJob = require('./setUpJob.task');
@@ -28,6 +29,7 @@ const release = async () => {
   const result = await semanticRelease({
     ...handleBranchesOption(),
     ...handleDryRunOption(),
+    ...handleCiOption(),
     ...handleExtends(),
   });
 

--- a/src/inputs.json
+++ b/src/inputs.json
@@ -4,6 +4,7 @@
   "branch": "branch",
   "extra_plugins": "extra_plugins",
   "dry_run": "dry_run",
+  "ci": "ci",
   "extends": "extends",
   "working_directory": "working_directory"
 }


### PR DESCRIPTION
### Type of Change

<!-- What type of change does your code introduce? -->
- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves

-  I did not find any related issues, nor did I create one (sorry). Creating a pull request directly was the fastest way for me to ask for this feature.

### Describe Changes
<!-- Describe your changes in detail, if applicable. -->

I recently tried to use this action to comment the next version number under pull request that merge back into main. However, `semantic-release` blocks the release generation when the job is executed on a pull request. The option `ci = false` can be used to disable the pull request detection.

I'm sure there are other use-cases and I think it would be good to expose the `ci` config for `semantic-release`. I checked the changelog, and apparently `ci` was added in [v16.0.0](https://github.com/semantic-release/semantic-release/releases/tag/v16.0.0), initally as `noCi` and later renamed to `ci`. In the `handleOptions` I have added both options in order to support all versions above v16.0.0.

If this is not a feature that is intended to be added, feel free to just close the pull request, I'd be completely fine with that and can call semantic release myself in my action.