### PR TITLE
fix(preInstall): disable silent flag if debug mode is enabled

### DIFF
--- a/src/preInstall.task.js
+++ b/src/preInstall.task.js
@@ -12,8 +12,9 @@ module.exports = async extras => {
   }
 
   const _extras = extras.replace(/['"]/g, '').replace(/[\n\r]/g, ' ');
+  const silentFlag = process.env.RUNNER_DEBUG == '1' ? '' : '--silent';
 
-  const { stdout, stderr } = await exec(`npm install ${_extras} --silent`, {
+  const { stdout, stderr } = await exec(`npm install ${_extras} ${silentFlag}`, {
     cwd: path.resolve(__dirname, '..')
   });
   core.debug(stdout);


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
N/A

### Describe Changes
<!-- Describe your changes in detail, if applicable. -->
Disable npm `--silent` flag if debug mode is enabled. This allows to get more information about the error that happened during installation, instead of just "npm command failed".
Debug mode can be enabled when re-running a failed job and checking the "Enable debug logging" checkbox.

