### PR TITLE
fix(windUpJob): set last_release outputs before returning

### DIFF
--- a/src/windUpJob.task.js
+++ b/src/windUpJob.task.js
@@ -16,7 +16,9 @@ module.exports = async (result) => {
 
   if (lastRelease.version) {
     core.debug(`The last release was "${lastRelease.version}".`);
-    core.setOutput(outputs.last_release_version, lastRelease.version)
+    core.setOutput(outputs.last_release_version, lastRelease.version);
+    core.setOutput(outputs.last_release_git_head, lastRelease.gitHead);
+    core.setOutput(outputs.last_release_git_tag, lastRelease.gitTag);
   }
 
   if (!nextRelease) {
@@ -43,7 +45,4 @@ module.exports = async (result) => {
   core.setOutput(outputs.new_release_notes, notes);  
   core.setOutput(outputs.new_release_git_head, gitHead);
   core.setOutput(outputs.new_release_git_tag, gitTag);
-  core.setOutput(outputs.last_release_version, lastRelease.version);
-  core.setOutput(outputs.last_release_git_head, lastRelease.gitHead);
-  core.setOutput(outputs.last_release_git_tag, lastRelease.gitTag);
 };


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- N/A

### Describe Changes
<!-- Describe your changes in detail, if applicable. -->
When no new release has been published, the outputs related to the last one are not set. This PR sets these outputs as soon as we have the needed information about the last release.

