### PR TITLE
feat: add ability to unset GITHUB_ACTION env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ then make sure that you configure this in your `package.json` file:
 |   extra_plugins   |  false   | Extra plugins for pre-install. [[Details](#extra_plugins)]                                                               |
 |      dry_run      |  false   | Whether to run semantic release in `dry-run` mode. [[Details](#dry_run)]                                                 |
 |        ci         |  false   | Whether to run semantic release with CI support. [[Details](#ci)]<br>Support for **semantic-release above v16**.         |
+|   unset_gha_env   |  false   | Whether to unset the GITHUB_ACTIONS environment variable.                                                                |
 |      extends      |  false   | Use a sharable configuration [[Details](#extends)]                                                                       |
 | working_directory |  false   | Use another working directory for semantic release [[Details](#working_directory)]                                       |
 |    tag_format     |  false   | Specify format of tag (useful for monorepos)                                                                             |

--- a/README.md
+++ b/README.md
@@ -265,6 +265,29 @@ steps:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
 
+#### unset_gha_env
+Setting this to true will unset the `GITHUB_ACTIONS` environment variable. This can be useful when wanting to validate things such as merging of a PR would create a valid release.
+
+```yaml
+steps:
+  - name: Checkout
+    uses: actions/checkout@v4
+  - name: Temporarily merge PR branch
+    if: ${{ github.event_name == 'pull_request' }}
+    run: |
+      git config --global user.name github-actions
+      git config --global user.email github-actions@github.com
+      git merge --no-ff origin/${{ github.event.pull_request.head.ref }} --message "${{ github.event.pull_request.title }}"
+  - name: Semantic Release
+    uses: cycjimmy/semantic-release-action@v4
+    with:
+      unset_gha_env: ${{ github.event_name == 'pull_request' }}
+      ci: ${{ github.event_name == 'pull_request' && false || '' }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
 ### Outputs
 |     Output Parameter      | Description                                                                                                                       |
 |:-------------------------:|-----------------------------------------------------------------------------------------------------------------------------------|

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   ci:
     required: false
     description: 'Whether to run semantic release with CI support (default: true). It will override the ci attribute in your configuration file'
+  unset_gha_env:
+    required: false
+    description: 'Whether to unset the GITHUB_ACTIONS environment variable. This can be useful when trying to run semantic-release as part of PR checks.'
   extends:
     required: false
     description: 'One or several sharable configurations, https://semantic-release.gitbook.io/semantic-release/usage/configuration#extends'

--- a/src/handleOptions.js
+++ b/src/handleOptions.js
@@ -126,7 +126,7 @@ exports.handleRepositoryUrlOption = () => {
   core.debug(`repository_url input: ${repositoryUrl}`);
 
   if (repositoryUrl) {
-    return { r: repositoryUrl }; 
+    return { r: repositoryUrl };
   } else {
     return {};
   }

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,11 @@ const release = async () => {
   await preInstall(core.getInput(inputs.extra_plugins));
   await preInstall(core.getInput(inputs.extends));
 
+  if (core.getInput(inputs.unset_gha_env) === 'true') {
+    core.debug('Unset GITHUB_ACTIONS environment variable');
+    delete process.env.GITHUB_ACTIONS;
+  }
+
   const semanticRelease = await import('semantic-release');
   const result = await semanticRelease.default({
     ...handleBranchesOption(),

--- a/src/inputs.json
+++ b/src/inputs.json
@@ -5,6 +5,7 @@
   "extra_plugins": "extra_plugins",
   "dry_run": "dry_run",
   "ci": "ci",
+  "unset_gha_env": "unset_gha_env",
   "extends": "extends",
   "working_directory": "working_directory",
   "tag_format": "tag_format",


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- Fixes https://github.com/semantic-release/semantic-release/issues/3518, https://github.com/semantic-release/semantic-release/issues/1890

### Describe Changes
<!-- Describe your changes in detail, if applicable. -->
This PR adds the ability to unset the `GITHUB_ACTIONS` environment variable. In a number of scenarios it can be useful to validate a PR being merged to a branch will result in a valid release. However, due to the way the detection works in [env-ci](https://github.com/semantic-release/env-ci/blob/master/services/github.js) it will always pick up the branch from GitHub from environment variables that can't be overridden, even when setting `ci: false`. Removing the `GITHUB_ACTIONS` environment variable allows semantic release to pickup the branch from Git. This allows for a workflow to checkout the base branch of a PR, do a dummy merge of the PR and then run semantic release in dry-run mode to ensure a valid release would be created if the PR is merged. Such a workflow can be very helpful in environments where pre-commit hooks aren't easy to implement or desirable like open source projects.

