### PR TITLE
fix(cleanupNpmrc.task.js): Use @actions/io to remove .npmrc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",
+        "@actions/io": "^1.1.3",
         "@cycjimmy/awesome-js-funcs": "^4.0.9",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/cycjimmy/semantic-release-action#readme",
   "dependencies": {
     "@actions/core": "^1.10.1",
+    "@actions/io": "^1.1.3",
     "@cycjimmy/awesome-js-funcs": "^4.0.9",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",

--- a/src/cleanupNpmrc.task.js
+++ b/src/cleanupNpmrc.task.js
@@ -1,15 +1,9 @@
-const core = require('@actions/core');
-const exec = require('./_exec');
+const io = require('@actions/io');
 
 /**
  * Clean up `.npmrc` file in the repo after releasing
  * @returns {Promise<never>}
  */
 module.exports = async () => {
-  const {stdout, stderr} = await exec(`rm -f .npmrc`);
-  core.debug(stdout);
-
-  if (stderr) {
-    return Promise.reject(stderr);
-  }
+  await io.rmRF('.npmrc');
 };


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- Fixes `Error: Command failed: rm -f .npmrc` when running on a Windows runner:
```console
[11:38:40 AM] [semantic-release] » √  Completed step "success" of plugin "@semantic-release/exec"
[11:38:40 AM] [semantic-release] » √  Published release 1.0.0 on default channel
Error: Error: Command failed: rm -f .npmrc
'rm' is not recognized as an internal or external command,
```

### Describe Changes
<!-- Describe your changes in detail, if applicable. -->
Use package `@actions/io` for OS independent filesystem access, here `rm -rf` in `cleanupNpmrc.task.js`.

