### PR TITLE
feat!: update node version on runner to 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Node.js with GitHub Package Registry
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://npm.pkg.github.com'
           scope: 'cycjimmy'
 

--- a/action.yml
+++ b/action.yml
@@ -64,5 +64,5 @@ outputs:
   last_release_git_tag:
     description: 'The Git tag associated with the last release, if there was one.'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- Fixes #247

### Describe Changes
The action now uses node 24 so that users can release libraries that require node 22 or 24. See https://github.com/cycjimmy/semantic-release-action/issues/247 for details.

BREAKING CHANGE: this action now runs using node 24