### PR TITLE
fix: improves result handling in windUpJob.task.js

### DIFF
--- a/src/windUpJob.task.js
+++ b/src/windUpJob.task.js
@@ -26,7 +26,7 @@ module.exports = async (result) => {
     core.setOutput(outputs.last_release_git_head, lastRelease.gitHead);
     core.setOutput(outputs.last_release_git_tag, lastRelease.gitTag);
   }
-  
+
   if (!nextRelease) {
     core.debug('No release published.');
     return;


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [x] Refactor
- [ ] Chore

### Resolves
Resolves #263 

### Describe Changes
Promise was checked before resolving, so the first early return never happened (Promises are truthy) and the subsequent `if (lastRelease.version)` check produced an error in some cases(`lastRelease` undefined, "Error: TypeError: Cannot read properties of undefined (reading 'version')"). 

Observed for semantic-release-action 4.2.2 and 5.0.0 with semantic_version > 24.2.6 (not observed with 24.2.6). 

The PR prevents reading properties of "undefined".

