### PR TITLE
fix: further fix of result handling in windUpJob.task.js

### DIFF
--- a/src/windUpJob.task.js
+++ b/src/windUpJob.task.js
@@ -27,7 +27,7 @@ module.exports = async (result) => {
     core.setOutput(outputs.last_release_git_tag, lastRelease.gitTag);
   }
 
-  if (!nextRelease) {
+  if (!nextRelease?.version) {
     core.debug('No release published.');
     return;
   }


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- Fixes #264

### Describe Changes
<!-- Describe your changes in detail, if applicable. -->
Further null check of semantic_release result for the case of no new release published (in addition to #262)

