### PR TITLE
docs: describe semantic_version default as latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ steps:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
 
-If no version range is specified with `cycjimmy/semantic-release-action@v6` then [semantic-release](https://github.com/semantic-release/semantic-release/) version [24.2.7](https://github.com/semantic-release/semantic-release/releases/tag/v25.0.2) is used.
+If no version range is specified with `cycjimmy/semantic-release-action@v6` then [semantic-release@latest](https://github.com/semantic-release/semantic-release/releases) is used.
 
 #### branches
 > {Optional Input Parameter} The branches on which releases should happen.<br>`branches` supports for **semantic-release above v16**.


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [ ] Bug fix
- [X] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves

- Closes https://github.com/cycjimmy/semantic-release-action/issues/293

### Situation

The [README > semantic_version](https://github.com/cycjimmy/semantic-release-action/blob/main/README.md#semantic_version) states:

> If no version range is specified with `cycjimmy/semantic-release-action@v6` then [semantic-release](https://github.com/semantic-release/semantic-release/) version [24.2.7](https://github.com/semantic-release/semantic-release/releases/tag/v25.0.2) is used.

with `24.2.7` text displayed and a link to https://github.com/semantic-release/semantic-release/releases/tag/v25.0.2

[src/installSpecifyingVersionSemantic.task.js](https://github.com/cycjimmy/semantic-release-action/blob/main/src/installSpecifyingVersionSemantic.task.js) however simply executes `npm install semantic-release` if `semantic_version` is not specified. [npm install](https://docs.npmjs.com/cli/v11/commands/npm-install) defaults to the `latest` tag if none is specified.

### Describe Changes

Update the [README > semantic_version](https://github.com/cycjimmy/semantic-release-action/blob/main/README.md#semantic_version) document section to reflect how the action works:

> If no version range is specified with `cycjimmy/semantic-release-action@v6` then [semantic-release@latest](https://github.com/semantic-release/semantic-release/releases) is used.